### PR TITLE
chore(security): pin actions to specific commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 on 2025-06-26, TODO: consider using a release
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 on 2025-06-26, TODO: consider using a release
       with:
         node-version: '18'
         cache: 'npm'
@@ -34,13 +34,13 @@ jobs:
       run: npm run build
       
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4 on 2025-06-26, TODO: consider using a release
       
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3 on 2025-06-26, TODO: consider using a release
       with:
         path: './dist'
         
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4 on 2025-06-26, TODO: consider using a release


### PR DESCRIPTION
# Pin GitHub Actions to commit hashes

This pull request pins all GitHub Actions in workflow files to specific commit hashes to improve security and ensure reproducible builds.

## Changes Made

- Converted version tags (e.g., `v3`, `v4`) to commit hashes
- Added comments showing the original version, date, and TODO reminders
- Preserved all existing functionality while improving security

## Benefits

- **Security**: Prevents supply chain attacks by ensuring immutable action references
- **Reproducibility**: Guarantees the same action version is used across all runs
- **Auditability**: Clear tracking of which specific version of each action is being used
- **Maintenance**: TODO comments remind to consider using releases when available

## Review Notes

- All pinned actions maintain their original functionality
- Comments preserve the original version information with dates for easy reference
- TODO comments suggest considering releases for better maintenance
- No workflow behavior changes are expected

This change follows GitHub's security best practices for action pinning.